### PR TITLE
display arrows on unsorted but sortable columns

### DIFF
--- a/screen.css
+++ b/screen.css
@@ -1,0 +1,3 @@
+div.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sorttable_nosort):after { 
+    content: " \25B4\25BE" 
+}


### PR DESCRIPTION
Display arrows by default, it's possible to make a difference between sortable and normal tables. This needs a browser which supports CSS generated content.

see http://www.kryogenix.org/code/browser/sorttable/#symbolsbeforesorting